### PR TITLE
don't include folders

### DIFF
--- a/s3-zip.js
+++ b/s3-zip.js
@@ -28,8 +28,11 @@ s3Zip.archiveStream = function (stream) {
   stream
    .on('data', function (file) {
       // console.log(file.data.toString());
+      if(file.path[file.path.length - 1] == '/'){
+        console.log('don\'t append to zip', file.path);
+        return;
+     }
      console.log('append to zip', file.path);
-     // archive.append(file, { name: 'x.png' });
      archive.append(file.data, { name: file.path });
    })
    .on('end', function () {


### PR DESCRIPTION
Hi,
I like your project. :)

I added a small change so that s3-zip doesn't try to include the folders directly into an archive. When zipping a folder with subfolder archiver does it correctly and creates folders inside the archive so you preserve the structure which one had on S3.