### PR TITLE
Allow renaming the files going into the zip archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 coverage/*
 node_modules/*
 test/test.zip
+test/test_alt.zip

--- a/s3-zip.js
+++ b/s3-zip.js
@@ -4,22 +4,22 @@ var archiver = require('archiver');
 
 module.exports = s3Zip = {};
 
-s3Zip.archive = function (opts, folder, files) {
+s3Zip.archive = function (opts, folder, files_s3, files_zip) {
   var self = this;
   var keyStream = s3Files
     .connect({
       region: opts.region,
       bucket: opts.bucket
     })
-    .createKeyStream(folder, files);
+    .createKeyStream(folder, files_s3);
 
   var fileStream = s3Files.createFileStream(keyStream);
-  var archive = self.archiveStream(fileStream);
+  var archive = self.archiveStream(fileStream, files_s3, files_zip);
   return archive;
 };
 
 
-s3Zip.archiveStream = function (stream) {
+s3Zip.archiveStream = function (stream, files_s3, files_zip) {
   var archive = archiver('zip');
   archive.on('error', function (err) {
     console.log('archive error', err);
@@ -32,8 +32,18 @@ s3Zip.archiveStream = function (stream) {
        console.log('don\'t append to zip', file.path);
        return;
      }
-     console.log('append to zip', file.path);
-     archive.append(file.data, { name: file.path });
+     var fname;
+     if (files_zip) {
+       // Place files_s3[i] into the archive as files_zip[i]
+       var i = files_s3.indexOf(file.path);
+       fname = (i >= 0 && i < files_zip.length) ? files_zip[i] : file.path;
+     }
+     else {
+       // Just use the S3 file name
+       fname = file.path;
+     }
+     console.log('append to zip', fname);
+     archive.append(file.data, { name: fname });
    })
    .on('end', function () {
      console.log('end -> finalize');

--- a/test/test_s3_zip_alt_names.js
+++ b/test/test_s3_zip_alt_names.js
@@ -1,0 +1,89 @@
+// Test s3-zip BUT using alternate file names in the resulting zip archive
+
+var s3Zip = require('../s3-zip.js');
+var t = require('tap');
+var fs = require('fs');
+var Stream = require('stream');
+var concat = require('concat-stream');
+var yauzl = require('yauzl');
+
+var fileStream = function (file, forceError) {
+  var rs = new Stream();
+  rs.readable = true;
+  var fileStream = fs.createReadStream(__dirname + file);
+  fileStream
+    .pipe(concat(
+      function buffersEmit (buffer) {
+        if (forceError) {
+          console.log('send end to finalize archive');
+          rs.emit('end');
+        } else {
+          rs.emit('data', { data: buffer, path: file });
+        }
+      })
+    );
+  fileStream
+    .on('end', function () {
+      console.log('end fileStream');
+      rs.emit('end');
+    });
+  return rs;
+};
+
+
+var file1 = '/fixtures/file.txt';
+var file1_alt = 'FILE_ALT.TXT';
+// Stub: var fileStream = s3Files.createFileStream(keyStream);
+var sinon = require('sinon');
+var proxyquire = require('proxyquire');
+var s3Stub = fileStream(file1);
+s3Zip = proxyquire('../s3-zip.js', {
+  's3-files': { 'createFileStream': sinon.stub().returns(s3Stub) }
+});
+
+
+t.test('test archiveStream and zip file with alternate file name in zip archive', function (child) {
+  var output = fs.createWriteStream(__dirname + '/test_alt.zip');
+  var s = fileStream(file1);
+  var archive = s3Zip
+    .archiveStream(s, [file1], [file1_alt])
+    .pipe(output);
+  archive.on('close', function () {
+    console.log('+++++++++++');
+    yauzl.open(__dirname + '/test_alt.zip', function (err, zip) {
+      if (err) console.log('err', err);
+      zip.on('entry', function (entry) {
+        // console.log(entry);
+        child.same(entry.fileName, file1_alt);
+        child.same(entry.compressedSize, 11);
+        child.same(entry.uncompressedSize, 20);
+      });
+
+      zip.on('close', function () {
+        child.end();
+      });
+    });
+  });
+  child.type(archive, 'object');
+});
+
+// t.test('test archiveStream error', function (child) {
+//   var s = fileStream(file1, true);
+//   var a = s3Zip.archiveStream(s);
+//   a.on('error', function (e) {
+//     child.equal(e.message, 'finalize: archive already finalizing');
+//     child.end();
+//   });
+// });
+
+
+t.test('test archive with alternate zip archive names', function (child) {
+  var archive = s3Zip
+    .archive({ region: 'region', bucket: 'bucket' },
+      'folder',
+      [file1],
+      [file1_alt]
+    );
+  child.type(archive, 'object');
+  child.end();
+});


### PR DESCRIPTION
For your consideration.

This change allows the file names in the zip archive to be changed from the underlying names in S3 to some other, possibly, meaningful names.  This is useful, for instance, when in S3 the files are stored using random, unique names to prevent name collisions.  When archiving the files to a zip file, more meaningful names can be restored.

The code extends s3-zip's archive() function to accept an optional fourth call argument which is a list of the file names as they should appear in the zip archive.  There is a 1:1 correspondence between the names in the third call argument and those in the fourth, if supplied.  E.g., for

    s3Zip({region: 'us-east-1', bucket: 'bring.me.a.bucket'}, 'a/thin/mint/',
             ['57b1e3a1a603ca5e11cf68d8.pdf', '5807c40c75be49ed6d8e2021.txt'],
             ['contract.pdf', 'license.txt']);

the S3 file `57b1e3a1a603ca5e11cf68d8.pdf` would be archived as `contract.pdf` while the S3 file `5807c40c75be49ed6d8e2021.txt` would be archived as `license.txt`.

