### PR TITLE
Handle empty file

### DIFF
--- a/s3-zip.js
+++ b/s3-zip.js
@@ -41,7 +41,11 @@ s3Zip.archiveStream = function (stream, filesS3, filesZip) {
        fname = file.path
      }
      console.log('append to zip', fname)
-     archive.append(file.data, { name: fname })
+     if (file.data.length === 0) {
+       archive.append('', { name: fname })
+     } else {
+       archive.append(file.data, { name: fname })
+     }
    })
    .on('end', function () {
      console.log('end -> finalize')

--- a/test/test_s3_zip.js
+++ b/test/test_s3_zip.js
@@ -30,6 +30,7 @@ var fileStream = function (file, forceError) {
 }
 
 var file1 = '/fixtures/file.txt'
+var emptyFile = '/fixtures/empty.txt'
 // Stub: var fileStream = s3Files.createFileStream(keyStream);
 var sinon = require('sinon')
 var proxyquire = require('proxyquire')
@@ -71,4 +72,29 @@ t.test('test archive', function (child) {
     )
   child.type(archive, 'object')
   child.end()
+})
+
+t.test('test archive on empty file', function (child) {
+  var output = fs.createWriteStream(join(__dirname, '/test.zip'))
+  var s = fileStream(emptyFile)
+  var archive = s3Zip
+    .archiveStream(s)
+    .pipe(output)
+  archive.on('close', function () {
+    console.log('+++++++++++')
+    yauzl.open(join(__dirname, '/test.zip'), function (err, zip) {
+      if (err) console.log('err', err)
+      zip.on('entry', function (entry) {
+        // console.log(entry);
+        child.same(entry.fileName, 'fixtures/empty.txt')
+        child.same(entry.compressedSize, 0)
+        child.same(entry.uncompressedSize, 0)
+      })
+
+      zip.on('close', function () {
+        child.end()
+      })
+    })
+  })
+  child.type(archive, 'object')
 })


### PR DESCRIPTION
Hi — small change to handle archiving empty files. I found that trying to archive a file that exists but is empty will result in this append error (this snippet is the result of running the new test without this change).
```
+++++++++++
.....append to zip /fixtures/empty.txt
test/test_s3_zip.js ................................... 6/7
  test archive on empty file
  not ok Error: append: input source must be valid Stream or Buffer instance
    at:
      line: 525
      column: 24
      file: node_modules/archiver/lib/core.js
      function: Archiver.append
    stack: >
      Archiver.append (node_modules/archiver/lib/core.js:525:24)
    
      Stream.<anonymous> (s3-zip.js:11:31)
    
      buffersEmit (test/test_s3_zip.js:20:14)
    
      ConcatStream.<anonymous> (node_modules/concat-stream/index.js:36:43)
    
      finishMaybe (node_modules/readable-stream/lib/_stream_writable.js:513:14)
    
      endWritable (node_modules/readable-stream/lib/_stream_writable.js:523:3)
    
      ConcatStream.Writable.end
      (node_modules/readable-stream/lib/_stream_writable.js:493:41)
    
      ReadStream.onend (_stream_readable.js:511:10)
    
      endReadableNT (_stream_readable.js:974:12)
    test: test archive on empty file
    message: 'Error: append: input source must be valid Stream or Buffer instance'
    source: >
      this.emit('error', new Error('append: input source must be valid Stream or
      Buffer instance'));
```

This is because calling `file.data` on an empty file returns `[]`, not a `Buffer`. I just added a check for this and return an empty string instead.