### PR TITLE
Pass custom s3 client

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ s3Zip
 
 ```
 
+You can also pass a custom S3 client. For example if you want to zip files from a S3 compatible storage:
+
+```javascript
+var aws = require('aws-sdk')
+
+var s3Client = new aws.S3({
+    signatureVersion: 'v4',
+    s3ForcePathStyle: 'true',
+    endpoint: 'http://localhost:9000',
+})
+
+s3Zip
+  .archive({ s3: s3Client, bucket: 'boom' }, folder, [file1, file2])
+  .pipe(output)
+```
+
 ### Zip files with AWS Lambda
 
 Example of s3-zip in combination with [AWS Lambda](aws_lambda.md).

--- a/s3-zip.js
+++ b/s3-zip.js
@@ -6,12 +6,22 @@ module.exports = s3Zip
 
 s3Zip.archive = function (opts, folder, filesS3, filesZip) {
   var self = this
-  var keyStream = s3Files
-    .connect({
+  var connectionConfig
+
+  if('s3' in opts) {
+    connectionConfig = {
+      s3: opts.s3
+    }
+  } else {
+    connectionConfig = {
       region: opts.region,
       bucket: opts.bucket
-    })
-    .createKeyStream(folder, filesS3)
+    }
+  }
+
+  self.client = s3Files.connect(connectionConfig)
+
+  var keyStream = self.client.createKeyStream(folder, filesS3)
 
   var fileStream = s3Files.createFileStream(keyStream, opts.preserveFolderStructure)
   var archive = self.archiveStream(fileStream, filesS3, filesZip)

--- a/s3-zip.js
+++ b/s3-zip.js
@@ -8,7 +8,7 @@ s3Zip.archive = function (opts, folder, filesS3, filesZip) {
   var self = this
   var connectionConfig
 
-  if('s3' in opts) {
+  if ('s3' in opts) {
     connectionConfig = {
       s3: opts.s3
     }

--- a/s3-zip.js
+++ b/s3-zip.js
@@ -14,10 +14,11 @@ s3Zip.archive = function (opts, folder, filesS3, filesZip) {
     }
   } else {
     connectionConfig = {
-      region: opts.region,
-      bucket: opts.bucket
+      region: opts.region
     }
   }
+
+  connectionConfig.bucket = opts.bucket
 
   self.client = s3Files.connect(connectionConfig)
 


### PR DESCRIPTION
Sometimes we need to pass more options to the S3 client in different projects. This PR allows users to pass their pre-connected S3 client to the module.