### PR TITLE
remove emit error from archive

### DIFF
--- a/s3-zip.js
+++ b/s3-zip.js
@@ -31,9 +31,6 @@ s3Zip.archive = function (opts, folder, filesS3, filesZip) {
   var preserveFolderStructure = opts.preserveFolderStructure === true || filesZip
   var fileStream = s3Files.createFileStream(keyStream, preserveFolderStructure)
   var archive = self.archiveStream(fileStream, filesS3, filesZip)
-  fileStream.on('error', function (err) {
-    archive.emit('error', err)
-  })
 
   return archive
 }


### PR DESCRIPTION
Removing unwanted `emit` of error. Error is already being emitted from the function `archiveStream`. Having another `emit` causes the error twice resulting in the stream emitting error one after another.