### PR TITLE
Allow alternate names for each instance of a repeated S3 file

### DIFF
--- a/s3-zip.js
+++ b/s3-zip.js
@@ -56,6 +56,7 @@ s3Zip.archiveStream = function (stream, filesS3, filesZip) {
         // Place files_s3[i] into the archive as files_zip[i]
         const i = filesS3.indexOf(file.path.startsWith(folder) ? file.path.substr(folder.length) : file.path)
         fname = (i >= 0 && i < filesZip.length) ? filesZip[i] : file.path
+        filesS3[i] = ''
       } else {
         // Just use the S3 file name
         fname = file.path

--- a/test/test-s3-same-file-alt-names.js
+++ b/test/test-s3-same-file-alt-names.js
@@ -46,8 +46,6 @@ var outputFiles = [
 ]
 var filesRead = []
 
-filesRead = []
-
 t.test('test a tar archive with alternate names for one file listed many times', function (child) {
   var outputPath = join(__dirname, '/test-same_file_alt_name.tar')
   var output = fs.createWriteStream(outputPath)

--- a/test/test-s3-same-file-alt-names.js
+++ b/test/test-s3-same-file-alt-names.js
@@ -1,0 +1,118 @@
+// Test s3-zip BUT using alternate file names for the same file which is listed multiple times
+
+var s3Zip = require('../s3-zip.js')
+var t = require('tap')
+var fs = require('fs')
+var Stream = require('stream')
+var concat = require('concat-stream')
+var join = require('path').join
+var streamify = require('stream-array')
+var tar = require('tar')
+var yauzl = require('yauzl')
+
+var fileStreamForFiles = function (files, preserveFolderPath) {
+  var rs = new Stream()
+  rs.readable = true
+
+  var fileCounter = 0
+  streamify(files).on('data', function (file) {
+    fileCounter += 1
+
+    var fileStream = fs.createReadStream(join(__dirname, file))
+    fileStream.pipe(
+      concat(function buffersEmit (buffer) {
+        // console.log('buffers concatenated, emit data for ', file);
+        var path = preserveFolderPath ? file : file.replace(/^.*[\\/]/, '')
+        rs.emit('data', { data: buffer, path: path })
+      })
+    )
+    fileStream.on('end', function () {
+      fileCounter -= 1
+      if (fileCounter < 1) {
+        // console.log('all files processed, emit end');
+        rs.emit('end')
+      }
+    })
+  })
+  return rs
+}
+
+var inputFiles = [
+  '/fixtures/folder/a/file.txt',
+  '/fixtures/folder/a/file.txt'
+]
+var outputFiles = [
+  'FILE_1_ALT_1.TXT',
+  'FILE_1_ALT_2.TXT'
+]
+var filesRead = []
+
+filesRead = []
+
+t.test('test a tar archive with alternate names for one file listed many times', function (child) {
+  var outputPath = join(__dirname, '/test-same_file_alt_name.tar')
+  var output = fs.createWriteStream(outputPath)
+  var archive = s3Zip
+    .setFormat('tar')
+    .archiveStream(fileStreamForFiles(inputFiles, true), inputFiles, outputFiles)
+    .pipe(output)
+
+  archive.on('close', function () {
+    fs.createReadStream(outputPath)
+      .pipe(tar.list())
+      .on('entry', function (entry) {
+        filesRead.push(entry.path)
+      })
+      .on('end', function () {
+        child.same(filesRead, outputFiles)
+        child.end()
+      })
+  })
+})
+
+t.test('test archive with alternate names for one file listed many times', function (child) {
+  var archive = s3Zip
+    .archive({ region: 'region', bucket: 'bucket' },
+      '',
+      inputFiles,
+      outputFiles.map(file => {
+        return { name: file }
+      })
+    )
+
+  child.type(archive, 'object')
+  child.end()
+})
+
+filesRead = []
+
+t.test('test archive and zip file with alternate names for one file listed many times', function (child) {
+  var outputPath = join(__dirname, '/test-same_file_alt_name.zip')
+  var output = fs.createWriteStream(outputPath)
+  var archive = s3Zip
+    .archive(
+      { region: 'region', bucket: 'bucket' },
+      '',
+      inputFiles,
+      outputFiles
+    )
+    .pipe(output)
+
+  archive.on('close', function () {
+    yauzl.open(outputPath, function (err, zip) {
+      if (err) console.log('err', err)
+      zip.on('entry', function (entry) {
+        filesRead.push(entry.fileName)
+      })
+
+      zip.on('close', function () {
+        console.log('-----------------------FILES READ - ', filesRead)
+        console.log('-----------------------OUTPUT FILES - ', outputFiles)
+        child.same(filesRead, outputFiles)
+        child.end()
+      })
+    })
+  })
+
+  child.type(archive, 'object')
+})

--- a/test/test-s3-same-file-alt-names.js
+++ b/test/test-s3-same-file-alt-names.js
@@ -8,7 +8,6 @@ var concat = require('concat-stream')
 var join = require('path').join
 var streamify = require('stream-array')
 var tar = require('tar')
-var yauzl = require('yauzl')
 
 var fileStreamForFiles = function (files, preserveFolderPath) {
   var rs = new Stream()
@@ -82,37 +81,4 @@ t.test('test archive with alternate names for one file listed many times', funct
 
   child.type(archive, 'object')
   child.end()
-})
-
-filesRead = []
-
-t.test('test archive and zip file with alternate names for one file listed many times', function (child) {
-  var outputPath = join(__dirname, '/test-same_file_alt_name.zip')
-  var output = fs.createWriteStream(outputPath)
-  var archive = s3Zip
-    .archive(
-      { region: 'region', bucket: 'bucket' },
-      '',
-      inputFiles,
-      outputFiles
-    )
-    .pipe(output)
-
-  archive.on('close', function () {
-    yauzl.open(outputPath, function (err, zip) {
-      if (err) console.log('err', err)
-      zip.on('entry', function (entry) {
-        filesRead.push(entry.fileName)
-      })
-
-      zip.on('close', function () {
-        console.log('-----------------------FILES READ - ', filesRead)
-        console.log('-----------------------OUTPUT FILES - ', outputFiles)
-        child.same(filesRead, outputFiles)
-        child.end()
-      })
-    })
-  })
-
-  child.type(archive, 'object')
 })


### PR DESCRIPTION
See [issue](https://github.com/orangewise/s3-zip/issues/66) for more info.

Let me know if the tests need to be changed.