### PR TITLE
fixing lambda example after AWS SDK v3 bump

### DIFF
--- a/aws_lambda.md
+++ b/aws_lambda.md
@@ -35,7 +35,7 @@ exports.handler = function (event, context) {
         (r) => {
           console.log(r)
           context.succeed(r)
-        }
+        },
         (e) => {
           console.log('zipFile.upload error', e)
           context.fail(err)


### PR DESCRIPTION
@orangewise @tarunrajput I had some issues with the example after the SDK v3 bump:
(1) I needed a Readable stream to use as the body of the Upload params
(2) The function `send` is not in the v3 Upload object. It uses `done`, which returns a promise

I tried to keep logging outcomes the same.