### PR TITLE
Quick wins: fix bug, clean up dead config, modernize

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - 18
-  - 16
-  - 14

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # s3-zip
 
 [![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Coverage Status][coveralls-badge]][coveralls-url]
+[![Build Status][gh-actions-badge]][gh-actions-url]
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 Download selected files from an Amazon S3 bucket as a zip file.
@@ -96,7 +95,7 @@ const files = s3.listObjects(params).createReadStream()
 const xml = new XmlStream(files)
 xml.collect('Key')
 xml.on('endElement: Key', function(item) {
-  filesArray.push(item['$text'].substr(folder.length))
+  filesArray.push(item['$text'].substring(folder.length))
 })
 
 xml
@@ -219,9 +218,7 @@ The workflow can also be triggered manually from the Actions tab for testing pur
 [aws-sdk-url]: https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/configuring-the-jssdk.html
 [npm-badge]: https://badge.fury.io/js/s3-zip.svg
 [npm-url]: https://badge.fury.io/js/s3-zip
-[travis-badge]: https://travis-ci.org/orangewise/s3-zip.svg?branch=master
-[travis-url]: https://travis-ci.org/orangewise/s3-zip
-[coveralls-badge]: https://coveralls.io/repos/github/orangewise/s3-zip/badge.svg?branch=master
-[coveralls-url]: https://coveralls.io/github/orangewise/s3-zip?branch=master
+[gh-actions-badge]: https://github.com/orangewise/s3-zip/actions/workflows/test.yml/badge.svg?branch=master
+[gh-actions-url]: https://github.com/orangewise/s3-zip/actions/workflows/test.yml
 [archiver-url]: https://www.npmjs.com/package/archiver
 [entrydata-url]: https://archiverjs.com/docs/global.html#EntryData

--- a/aws_lambda.md
+++ b/aws_lambda.md
@@ -38,7 +38,7 @@ exports.handler = function (event, context) {
         },
         (e) => {
           console.log('zipFile.upload error', e)
-          context.fail(err)
+          context.fail(e)
         }
       )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "s3-zip",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Download selected files from an Amazon S3 bucket as a zip file.",
   "main": "s3-zip.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.3.2",
   "description": "Download selected files from an Amazon S3 bucket as a zip file.",
   "main": "s3-zip.js",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "test": "standard && tap --cov test/test*.js",
     "coverage": "npm test -- --cov --coverage-report=lcov"
@@ -31,7 +34,6 @@
   },
   "devDependencies": {
     "archiver-zip-encryptable": "^1.0.5",
-    "child_process": "^1.0.2",
     "concat-stream": "^2.0.0",
     "proxyquire": "^2.1.3",
     "sinon": "^16.0.0",

--- a/s3-zip.js
+++ b/s3-zip.js
@@ -62,7 +62,7 @@ s3Zip.archiveStream = function (stream, filesS3, filesZip) {
       let fname
       if (filesZip) {
         // Place files_s3[i] into the archive as files_zip[i]
-        const i = filesS3.indexOf(file.path.startsWith(folder) ? file.path.substr(folder.length) : file.path)
+        const i = filesS3.indexOf(file.path.startsWith(folder) ? file.path.substring(folder.length) : file.path)
         fname = (i >= 0 && i < filesZip.length) ? filesZip[i] : file.path
         filesS3[i] = ''
       } else {


### PR DESCRIPTION
- Fix ReferenceError bug in aws_lambda.md: `context.fail(err)` used
  undefined `err` instead of the caught error `e`
- Remove dead .travis.yml (CI moved to GitHub Actions)
- Update README badges from Travis CI / Coveralls to GitHub Actions
- Remove `child_process` from devDependencies (Node.js built-in)
- Replace deprecated `substr()` with `substring()` in source and docs
- Update CI test matrix: drop EOL Node 16, add Node 22 LTS
- Add `engines` field to package.json requiring Node >= 18

https://claude.ai/code/session_01JKExju3zGQqjgiWtPussP2